### PR TITLE
Move lb port definition from ScalewayCluster to Cluster

### DIFF
--- a/api/v1alpha1/scalewaycluster_types.go
+++ b/api/v1alpha1/scalewaycluster_types.go
@@ -15,7 +15,6 @@ const ClusterFinalizer = "scalewaycluster.infrastructure.cluster.x-k8s.io/sc-pro
 // +kubebuilder:validation:XValidation:rule="(has(self.network) && has(self.network.controlPlanePrivateDNS)) == (has(oldSelf.network) && has(oldSelf.network.controlPlanePrivateDNS))",message="controlPlanePrivateDNS cannot be added or removed"
 // +kubebuilder:validation:XValidation:rule="(has(self.network) && has(self.network.privateNetwork)) == (has(oldSelf.network) && has(oldSelf.network.privateNetwork))",message="privateNetwork cannot be added or removed"
 //
-// +kubebuilder:validation:XValidation:rule="(has(self.network) && has(self.network.controlPlaneLoadBalancer) && has(self.network.controlPlaneLoadBalancer.port)) == (has(oldSelf.network) && has(oldSelf.network.controlPlaneLoadBalancer) && has(oldSelf.network.controlPlaneLoadBalancer.port))",message="port cannot be added or removed"
 // +kubebuilder:validation:XValidation:rule="(has(self.network) && has(self.network.controlPlaneLoadBalancer) && has(self.network.controlPlaneLoadBalancer.private)) == (has(oldSelf.network) && has(oldSelf.network.controlPlaneLoadBalancer) && has(oldSelf.network.controlPlaneLoadBalancer.private))",message="private cannot be added or removed"
 // +kubebuilder:validation:XValidation:rule="(has(self.network) && has(self.network.controlPlaneLoadBalancer) && has(self.network.controlPlaneLoadBalancer.ip)) == (has(oldSelf.network) && has(oldSelf.network.controlPlaneLoadBalancer) && has(oldSelf.network.controlPlaneLoadBalancer.ip))",message="ip cannot be added or removed"
 // +kubebuilder:validation:XValidation:rule="(has(self.network) && has(self.network.controlPlaneLoadBalancer) && has(self.network.controlPlaneLoadBalancer.zone)) == (has(oldSelf.network) && has(oldSelf.network.controlPlaneLoadBalancer) && has(oldSelf.network.controlPlaneLoadBalancer.zone))",message="zone cannot be added or removed"
@@ -126,12 +125,6 @@ type ControlPlaneLoadBalancerSpec struct {
 	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.zone) || self.zone == oldSelf.zone",message="zone is immutable"
 	// +kubebuilder:validation:XValidation:rule="!has(oldSelf.privateIP) || self.privateIP == oldSelf.privateIP",message="privateIP is immutable"
 	LoadBalancerSpec `json:",inline"`
-
-	// Port configured on the Load Balancer. It must be valid port range (1-65535).
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable"
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port *int32 `json:"port,omitempty"`
 
 	// AllowedRanges allows to set a list of allowed IP ranges that can access
 	// the cluster through the loadbalancer. When unset, all IP ranges are allowed.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -28,11 +28,6 @@ func (in *ControlPlaneDNSSpec) DeepCopy() *ControlPlaneDNSSpec {
 func (in *ControlPlaneLoadBalancerSpec) DeepCopyInto(out *ControlPlaneLoadBalancerSpec) {
 	*out = *in
 	in.LoadBalancerSpec.DeepCopyInto(&out.LoadBalancerSpec)
-	if in.Port != nil {
-		in, out := &in.Port, &out.Port
-		*out = new(int32)
-		**out = **in
-	}
 	if in.AllowedRanges != nil {
 		in, out := &in.AllowedRanges, &out.AllowedRanges
 		*out = make([]CIDR, len(*in))

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_scalewayclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_scalewayclusters.yaml
@@ -170,16 +170,6 @@ spec:
                         description: IP to use when creating a loadbalancer.
                         format: ipv4
                         type: string
-                      port:
-                        description: Port configured on the Load Balancer. It must
-                          be valid port range (1-65535).
-                        format: int32
-                        maximum: 65535
-                        minimum: 1
-                        type: integer
-                        x-kubernetes-validations:
-                        - message: Value is immutable
-                          rule: self == oldSelf
                       private:
                         description: Private disables the creation of a public IP
                           on the LoadBalancers when it's set to true.
@@ -360,10 +350,6 @@ spec:
             - message: privateNetwork cannot be added or removed
               rule: (has(self.network) && has(self.network.privateNetwork)) == (has(oldSelf.network)
                 && has(oldSelf.network.privateNetwork))
-            - message: port cannot be added or removed
-              rule: (has(self.network) && has(self.network.controlPlaneLoadBalancer)
-                && has(self.network.controlPlaneLoadBalancer.port)) == (has(oldSelf.network)
-                && has(oldSelf.network.controlPlaneLoadBalancer) && has(oldSelf.network.controlPlaneLoadBalancer.port))
             - message: private cannot be added or removed
               rule: (has(self.network) && has(self.network.controlPlaneLoadBalancer)
                 && has(self.network.controlPlaneLoadBalancer.private)) == (has(oldSelf.network)

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_scalewayclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_scalewayclustertemplates.yaml
@@ -170,16 +170,6 @@ spec:
                                 description: IP to use when creating a loadbalancer.
                                 format: ipv4
                                 type: string
-                              port:
-                                description: Port configured on the Load Balancer.
-                                  It must be valid port range (1-65535).
-                                format: int32
-                                maximum: 65535
-                                minimum: 1
-                                type: integer
-                                x-kubernetes-validations:
-                                - message: Value is immutable
-                                  rule: self == oldSelf
                               private:
                                 description: Private disables the creation of a public
                                   IP on the LoadBalancers when it's set to true.
@@ -362,10 +352,6 @@ spec:
                     - message: privateNetwork cannot be added or removed
                       rule: (has(self.network) && has(self.network.privateNetwork))
                         == (has(oldSelf.network) && has(oldSelf.network.privateNetwork))
-                    - message: port cannot be added or removed
-                      rule: (has(self.network) && has(self.network.controlPlaneLoadBalancer)
-                        && has(self.network.controlPlaneLoadBalancer.port)) == (has(oldSelf.network)
-                        && has(oldSelf.network.controlPlaneLoadBalancer) && has(oldSelf.network.controlPlaneLoadBalancer.port))
                     - message: private cannot be added or removed
                       rule: (has(self.network) && has(self.network.controlPlaneLoadBalancer)
                         && has(self.network.controlPlaneLoadBalancer.private)) ==

--- a/docs/scalewaycluster.md
+++ b/docs/scalewaycluster.md
@@ -168,7 +168,6 @@ spec:
   network:
     controlPlaneLoadBalancer:
       type: LB-S
-      port: 443
       zone: fr-par-1
       ip: 42.42.42.42 # optional
       # private: true
@@ -177,8 +176,6 @@ spec:
 ```
 
 - The `type` field can be updated to migrate the Load Balancer to another type.
-- The `port` field specifies the port of the Load Balancer frontend that exposes the kube-apiserver(s).
-  This field is immutable.
 - The `zone` field specifies where the Load Balancer will be created. Must be in the same region
   as the `ScalewayCluster` region. This defaults to the first availability zone of the region.
   This field is immutable.
@@ -191,6 +188,26 @@ spec:
 > [!CAUTION]
 > When `private` is set to `true`, make sure your management cluster has network access
 > to the Private Network where the workload cluster will be created.
+
+The main Load Balancer's port can be set at the cluster creation in the `Cluster` object.
+
+Here is an example of the main Load Balancer port configuration:
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: my-cluster
+  namespace: default
+spec:
+  ...
+  clusterNetwork:
+    apiServerPort: 443
+  ...
+```
+
+- The `apiServerPort` field specifies the port of the Load Balancer frontend that exposes the kube-apiserver(s).
+  This field is immutable.
 
 #### Extra Load Balancers
 

--- a/internal/scope/cluster.go
+++ b/internal/scope/cluster.go
@@ -129,10 +129,9 @@ func (c *Cluster) PrivateNetworkID() (string, error) {
 func (c *Cluster) ControlPlaneLoadBalancerPort() int32 {
 	var port int32 = defaultFrontendControlPlanePort
 
-	if c.ScalewayCluster.Spec.Network != nil &&
-		c.ScalewayCluster.Spec.Network.ControlPlaneLoadBalancer != nil &&
-		c.ScalewayCluster.Spec.Network.ControlPlaneLoadBalancer.Port != nil {
-		port = *c.ScalewayCluster.Spec.Network.ControlPlaneLoadBalancer.Port
+	if c.Cluster.Spec.ClusterNetwork != nil &&
+		c.Cluster.Spec.ClusterNetwork.APIServerPort != nil {
+		port = *c.Cluster.Spec.ClusterNetwork.APIServerPort
 	}
 
 	return port

--- a/internal/scope/cluster_test.go
+++ b/internal/scope/cluster_test.go
@@ -9,6 +9,7 @@ import (
 	scwClient "github.com/scaleway/cluster-api-provider-scaleway/internal/service/scaleway/client"
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
 
@@ -311,7 +312,7 @@ func TestCluster_PrivateNetworkID(t *testing.T) {
 func TestCluster_ControlPlaneLoadBalancerPort(t *testing.T) {
 	t.Parallel()
 	type fields struct {
-		ScalewayCluster *infrav1.ScalewayCluster
+		Cluster *clusterv1.Cluster
 	}
 	tests := []struct {
 		name   string
@@ -321,19 +322,17 @@ func TestCluster_ControlPlaneLoadBalancerPort(t *testing.T) {
 		{
 			name: "empty spec",
 			fields: fields{
-				ScalewayCluster: &infrav1.ScalewayCluster{},
+				Cluster: &clusterv1.Cluster{},
 			},
 			want: defaultFrontendControlPlanePort,
 		},
 		{
 			name: "override with 443",
 			fields: fields{
-				ScalewayCluster: &infrav1.ScalewayCluster{
-					Spec: infrav1.ScalewayClusterSpec{
-						Network: &infrav1.NetworkSpec{
-							ControlPlaneLoadBalancer: &infrav1.ControlPlaneLoadBalancerSpec{
-								Port: scw.Int32Ptr(443),
-							},
+				Cluster: &clusterv1.Cluster{
+					Spec: clusterv1.ClusterSpec{
+						ClusterNetwork: &clusterv1.ClusterNetwork{
+							APIServerPort: scw.Int32Ptr(443),
 						},
 					},
 				},
@@ -345,7 +344,7 @@ func TestCluster_ControlPlaneLoadBalancerPort(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &Cluster{
-				ScalewayCluster: tt.fields.ScalewayCluster,
+				Cluster: tt.fields.Cluster,
 			}
 			if got := c.ControlPlaneLoadBalancerPort(); got != tt.want {
 				t.Errorf("Cluster.ControlPlaneLoadBalancerPort() = %v, want %v", got, tt.want)

--- a/internal/service/scaleway/lb/lb_test.go
+++ b/internal/service/scaleway/lb/lb_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/scaleway/scaleway-sdk-go/scw"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 const (
@@ -64,6 +65,12 @@ func TestService_Reconcile(t *testing.T) {
 			fields: fields{
 				Cluster: &scope.Cluster{
 					ScalewayCluster: &v1alpha1.ScalewayCluster{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "cluster",
+							Namespace: "default",
+						},
+					},
+					Cluster: &v1beta1.Cluster{
 						ObjectMeta: v1.ObjectMeta{
 							Name:      "cluster",
 							Namespace: "default",
@@ -149,6 +156,12 @@ func TestService_Reconcile(t *testing.T) {
 							Network: &infrav1.NetworkStatus{
 								PrivateNetworkID: scw.StringPtr(privateNetworkID),
 							},
+						},
+					},
+					Cluster: &v1beta1.Cluster{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      "cluster",
+							Namespace: "default",
 						},
 					},
 				},


### PR DESCRIPTION
:warning: This introduce an API definition breaking change.

This PR aims to use the `APIServerPort` field from the `Cluster` object instead of the previous `Port` from `ScalewayCluster` object to configure the LB exposing the kube-apiserver .